### PR TITLE
Bumps junit from 4.12 to 4.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,17 +18,12 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-			<version>4.12</version>
+			<version>4.13.2</version>
             <scope>test</scope>
         </dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.17.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
 			<version>2.17.2</version>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.17.2</version>
+			<version>2.18.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.jsqlparser</groupId>


### PR DESCRIPTION
To fix
Direct vulnerabilities:
CVE-2020-15250